### PR TITLE
Revamp `promstack` installer and update/upgrade services

### DIFF
--- a/.dockerenv
+++ b/.dockerenv
@@ -1,7 +1,9 @@
 # blackbox-exporter
+# https://github.com/prometheus/blackbox_exporter
 PROMSTACK_BLACKBOX_EXPORTER_VERSION=docker.io/prom/blackbox-exporter:v0.25.0
 
 # cadvisor
+# https://github.com/google/cadvisor
 PROMSTACK_CADVISOR_VERSION=gcr.io/cadvisor/cadvisor:v0.49.1
 
 # grafana
@@ -11,9 +13,11 @@ PROMSTACK_GRAFANA_CONFIG_PROVIDER_VERSION=docker.io/swarmlibs/prometheus-config-
 PROMSTACK_GRAFANA_CONFIG_RELOADER_VERSION=docker.io/swarmlibs/grafana-provisioning-config-reloader:0.1.0-rc.3
 
 # node-exporter
+# https://github.com/prometheus/node_exporter
 PROMSTACK_NODE_EXPORTER_VERSION=docker.io/prom/node-exporter:v1.8.1
 
 # prometheus
+# https://github.com/prometheus/prometheus
 PROMSTACK_PROMETHEUS_VERSION=docker.io/prom/prometheus:v3.0.0
 PROMSTACK_PROMETHEUS_GENCONFIG_VERSION=docker.io/swarmlibs/genconfig:0.1.0-rc.1
 PROMSTACK_PROMETHEUS_CONFIG_PROVIDER_VERSION=docker.io/swarmlibs/prometheus-config-provider:0.1.0-rc.1

--- a/.dockerenv
+++ b/.dockerenv
@@ -5,7 +5,8 @@ PROMSTACK_BLACKBOX_EXPORTER_VERSION=docker.io/prom/blackbox-exporter:v0.25.0
 PROMSTACK_CADVISOR_VERSION=gcr.io/cadvisor/cadvisor:v0.49.1
 
 # grafana
-PROMSTACK_GRAFANA_VERSION=docker.io/grafana/grafana:11.1.0
+# https://github.com/grafana/grafana
+PROMSTACK_GRAFANA_VERSION=docker.io/grafana/grafana:11.3.0
 PROMSTACK_GRAFANA_CONFIG_PROVIDER_VERSION=docker.io/swarmlibs/prometheus-config-provider:0.1.0-rc.1
 PROMSTACK_GRAFANA_CONFIG_RELOADER_VERSION=docker.io/swarmlibs/grafana-provisioning-config-reloader:0.1.0-rc.3
 

--- a/.dockerenv
+++ b/.dockerenv
@@ -13,7 +13,7 @@ PROMSTACK_GRAFANA_CONFIG_RELOADER_VERSION=docker.io/swarmlibs/grafana-provisioni
 PROMSTACK_NODE_EXPORTER_VERSION=docker.io/prom/node-exporter:v1.8.1
 
 # prometheus
-PROMSTACK_PROMETHEUS_VERSION=docker.io/prom/prometheus:v2.53.1
+PROMSTACK_PROMETHEUS_VERSION=docker.io/prom/prometheus:v3.0.0
 PROMSTACK_PROMETHEUS_GENCONFIG_VERSION=docker.io/swarmlibs/genconfig:0.1.0-rc.1
 PROMSTACK_PROMETHEUS_CONFIG_PROVIDER_VERSION=docker.io/swarmlibs/prometheus-config-provider:0.1.0-rc.1
 PROMSTACK_PROMETHEUS_CONFIG_RELOADER_VERSION=quay.io/prometheus-operator/prometheus-config-reloader:v0.74.0

--- a/.dockerenv
+++ b/.dockerenv
@@ -20,4 +20,5 @@ PROMSTACK_PROMETHEUS_CONFIG_PROVIDER_VERSION=docker.io/swarmlibs/prometheus-conf
 PROMSTACK_PROMETHEUS_CONFIG_RELOADER_VERSION=quay.io/prometheus-operator/prometheus-config-reloader:v0.74.0
 
 # pushgateway
-PROMSTACK_PUSHGATEWAY_VERSION=docker.io/prom/pushgateway:v1.9.0
+# https://github.com/prometheus/pushgateway
+PROMSTACK_PUSHGATEWAY_VERSION=docker.io/prom/pushgateway:v1.10.0

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ A Docker Stack deployment for the monitoring suite for Docker Swarm includes (Gr
 - [Stacks](#stacks)
 - [Pre-requisites](#pre-requisites)
 - [Getting Started](#getting-started)
-  - [Deploy stack](#deploy-stack)
-  - [Remove stack](#remove-stack)
-  - [Verify deployment](#verify-deployment)
+  - [Unattented deployment](#unattented-deployment)
+  - [Manually deploy `promstack` stack](#manually-deploy-promstack-stack)
+    - [Deploy stack](#deploy-stack)
+    - [Remove stack](#remove-stack)
+    - [Verify deployment](#verify-deployment)
 - [Grafana](#grafana)
     - [Injecting Grafana Dashboards](#injecting-grafana-dashboards)
     - [Injecting Grafana Provisioning configurations](#injecting-grafana-provisioning-configurations)
@@ -100,6 +102,28 @@ These are the services that are part of the stack:
 
 ## Getting Started
 
+There are two ways to deploy the `promstack` stack:
+- Unattented deployment
+- Manually deploy `promstack` stack
+
+The unattented deployment is the recommended way to deploy the stack. It will automatically create the necessary networks and deploy the stack to the Docker Swarm cluster.
+The manual deployment is useful for debugging and troubleshooting the stack.
+
+### Unattented deployment
+
+To deploy the stack, you can use the following command:
+
+```sh
+$ docker run -it --rm \
+    --name promstack \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    swarmlibs/promstack install
+```
+
+For more documentation, visit [here](https://github.com/swarmlibs/docker-promstack).
+
+### Manually deploy `promstack` stack
+
 To get started, clone this repository to your local machine:
 
 ```sh
@@ -134,7 +158,7 @@ The `grafana` and `prometheus` service requires extra services to operate, mainl
 
 See https://github.com/swarmlibs/swarmlibs for more information.
 
-### Deploy stack
+#### Deploy stack
 
 This will deploy the stack to the Docker Swarm cluster. Please ensure you have the necessary permissions to deploy the stack and the `swarmlibs` stack is deployed. See [Pre-requisites](#pre-requisites) for more information.
 
@@ -146,7 +170,7 @@ This will deploy the stack to the Docker Swarm cluster. Please ensure you have t
 make deploy
 ```
 
-### Remove stack
+#### Remove stack
 
 > [!WARNING]
 > This will remove the stack and all the services associated with it. Use with caution.
@@ -155,7 +179,7 @@ make deploy
 make remove
 ```
 
-### Verify deployment
+#### Verify deployment
 
 To verify the deployment, you can use the following commands:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Docker Stack deployment for the monitoring suite for Docker Swarm includes (Gr
   - [Manually deploy `promstack` stack](#manually-deploy-promstack-stack)
     - [Deploy stack](#deploy-stack)
     - [Remove stack](#remove-stack)
-    - [Verify deployment](#verify-deployment)
+  - [Verify deployment](#verify-deployment)
 - [Grafana](#grafana)
     - [Injecting Grafana Dashboards](#injecting-grafana-dashboards)
     - [Injecting Grafana Provisioning configurations](#injecting-grafana-provisioning-configurations)
@@ -179,7 +179,7 @@ make deploy
 make remove
 ```
 
-#### Verify deployment
+### Verify deployment
 
 To verify the deployment, you can use the following commands:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A Docker Stack deployment for the monitoring suite for Docker Swarm includes (Gr
 - [Services and Ports](#services-and-ports)
 - [Troubleshooting](#troubleshooting)
   - [Grafana dashboards are not present](#grafana-dashboards-are-not-present)
+  - [Promethues targets are not present](#promethues-targets-are-not-present)
 - [License](#license)
 
 
@@ -355,7 +356,33 @@ The following services and ports are exposed by the stack:
 If the Grafana dashboards are not present, please restart `grafana` service to reload the dashboards.
 
 ```sh
+# By force updating the service, it will restart the service and reload the dashboards.
 docker service update --force promstack_grafana
+```
+
+### Promethues targets are not present
+Please ensure the services are attached to the `prometheus` network. This is required to allow the Prometheus server to scrape the metrics.
+
+```yaml
+# Annotations:
+services:
+  my-app:
+    # ...
+    networks:
+      prometheus:
+    deploy:
+      # ...
+      labels:
+        io.prometheus.enabled: "true"
+        io.prometheus.job_name: "my-app"
+        io.prometheus.scrape_port: "8080"
+
+# As limitations of the Docker Swarm, you need to attach the service to the prometheus network.
+# This is required to allow the Prometheus server to scrape the metrics.
+networks:
+  prometheus:
+    name: prometheus
+    external: true
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ configs:
     name: gf-dashboard-grafana-metrics-v1
     file: ./dashboards/grafana-metrics.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
 ```
 
 #### Injecting Grafana Provisioning configurations
@@ -227,14 +227,14 @@ configs:
     name: gf-provisioning-dashboards-v1
     file: ./provisioning/dashboards/grafana-dashboards.yml
     labels:
-      - "io.grafana.provisioning.dashboard=true"
+      io.grafana.provisioning.dashboard: "true"
 
   # Grafana datasources provisioning config
   gf-provisioning-datasource-prometheus:
     name: gf-provisioning-datasource-prometheus-v1
     file: ./provisioning/datasources/prometheus.yaml
     labels:
-      - "io.grafana.provisioning.datasource=true"
+      io.grafana.provisioning.datasource: "true"
 ```
 
 ## Prometheus
@@ -287,7 +287,7 @@ configs:
     name: prometheus-cadvisor-v1
     file: ./prometheus/cadvisor.yml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
 ```
 
 ### Configure Prometheus

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ docker run -it --rm \
     swarmlibs/promstack install
 ```
 
-For more documentation, visit [here](https://github.com/swarmlibs/docker-promstack).
+For more documentation, visit https://github.com/swarmlibs/docker-promstack.
 
 ### Manually deploy `promstack` stack
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ docker service update --env-rm PROMETHEUS_SCRAPE_INTERVAL promstack_prometheus
 
 The following services and ports are exposed by the stack:
 
-| Service           | Port    | Mode   | Internal DNS                          |
+| Service           | Port    | Mode   | Cluster DNS                           |
 | ----------------- | ------- | ------ | ------------------------------------- |
 | Grafana           | `3000`  |        | `grafana.svc.cluster.local`           |
 | Prometheus        | `9090`  |        | `prometheus.svc.cluster.local`        |

--- a/blackbox-exporter/docker-stack.tmpl.yml
+++ b/blackbox-exporter/docker-stack.tmpl.yml
@@ -23,11 +23,11 @@ services:
     networks:
       public:
         aliases:
-          - blackbox-exporter.svc.promstack.local
+          - blackbox-exporter.svc.cluster.local
       prometheus_gwnetwork:
         aliases:
           - blackbox-exporter.internal
-          - blackbox-exporter.svc.promstack.local
+          - blackbox-exporter.svc.cluster.local
     hostname: replica-{{.Task.Slot}}.blackbox-exporter.internal
     configs:
       - source: prometheus-blackbox-exporter

--- a/blackbox-exporter/docker-stack.tmpl.yml
+++ b/blackbox-exporter/docker-stack.tmpl.yml
@@ -64,7 +64,7 @@ configs:
     name: prometheus-blackbox-exporter-v1
     file: ./prometheus/blackbox-exporter.yml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
 
 networks:
   public: # The 3rd-party ingress network

--- a/blackbox-exporter/docker-stack.yml
+++ b/blackbox-exporter/docker-stack.yml
@@ -41,10 +41,10 @@ services:
       prometheus_gwnetwork:
         aliases:
         - blackbox-exporter.internal
-        - blackbox-exporter.svc.promstack.local
+        - blackbox-exporter.svc.cluster.local
       public:
         aliases:
-        - blackbox-exporter.svc.promstack.local
+        - blackbox-exporter.svc.cluster.local
 networks:
   prometheus_gwnetwork:
     name: prometheus_gwnetwork

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -43,8 +43,8 @@ services:
         target: /var/lib/docker
         read_only: true
       - type: bind
-        source: /var/run
-        target: /var/run
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
         read_only: true
       # If you are running Docker Desktop on macOS,
       # You'll need to comment out the following bind mounts

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -19,9 +19,7 @@ services:
 
   cadvisor:
     image: ${PROMSTACK_CADVISOR_VERSION}
-    command:
-      - -docker_only=true
-      - -housekeeping_interval=10s
+    command: -docker_only
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -21,7 +21,7 @@ services:
     image: ${PROMSTACK_CADVISOR_VERSION}
     command:
       - -docker_only=true
-      - -housekeeping_interval=5s
+      - -allow_dynamic_housekeeping=true
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -19,7 +19,9 @@ services:
 
   cadvisor:
     image: ${PROMSTACK_CADVISOR_VERSION}
-    command: -docker_only
+    command:
+      - --docker_only
+      - --enable_load_reader=true
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -21,7 +21,7 @@ services:
     image: ${PROMSTACK_CADVISOR_VERSION}
     command:
       - -docker_only=true
-      - -housekeeping_interval=5s
+      - -housekeeping_interval=10s
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -90,4 +90,4 @@ configs:
     name: prometheus-cadvisor-v1
     file: ./prometheus/cadvisor.yml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -19,9 +19,7 @@ services:
 
   cadvisor:
     image: ${PROMSTACK_CADVISOR_VERSION}
-    command:
-      - --docker_only
-      - --enable_load_reader=true
+    command: -docker_only
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -21,7 +21,7 @@ services:
     image: ${PROMSTACK_CADVISOR_VERSION}
     command:
       - -docker_only=true
-      - -housekeeping_interval=10s
+      - -housekeeping_interval=5s
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -43,8 +43,8 @@ services:
         target: /var/lib/docker
         read_only: true
       - type: bind
-        source: /var/run/docker.sock
-        target: /var/run/docker.sock
+        source: /var/run
+        target: /var/run
         read_only: true
       # If you are running Docker Desktop on macOS,
       # You'll need to comment out the following bind mounts

--- a/cadvisor/docker-stack.tmpl.yml
+++ b/cadvisor/docker-stack.tmpl.yml
@@ -21,7 +21,7 @@ services:
     image: ${PROMSTACK_CADVISOR_VERSION}
     command:
       - -docker_only=true
-      - -allow_dynamic_housekeeping=true
+      - -housekeeping_interval=5s
     ports:
       - published: 18080
         target: 8080

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -3,8 +3,7 @@ services:
     cap_add:
     - SYSLOG
     command:
-    - -docker_only=true
-    - -housekeeping_interval=10s
+    - -docker_only
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -allow_dynamic_housekeeping=true
+    - -housekeeping_interval=5s
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -housekeeping_interval=5s
+    - -allow_dynamic_housekeeping=true
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -housekeeping_interval=5s
+    - -housekeeping_interval=10s
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -housekeeping_interval=10s
+    - -housekeeping_interval=5s
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -59,8 +59,8 @@ services:
       target: /var/lib/docker
       read_only: true
     - type: bind
-      source: /var/run
-      target: /var/run
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
       read_only: true
     - type: bind
       source: /dev/kmsg

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -59,8 +59,8 @@ services:
       target: /var/lib/docker
       read_only: true
     - type: bind
-      source: /var/run/docker.sock
-      target: /var/run/docker.sock
+      source: /var/run
+      target: /var/run
       read_only: true
     - type: bind
       source: /dev/kmsg

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -3,7 +3,8 @@ services:
     cap_add:
     - SYSLOG
     command:
-    - -docker_only
+    - --docker_only
+    - --enable_load_reader=true
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/cadvisor/docker-stack.yml
+++ b/cadvisor/docker-stack.yml
@@ -3,8 +3,7 @@ services:
     cap_add:
     - SYSLOG
     command:
-    - --docker_only
-    - --enable_load_reader=true
+    - -docker_only
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -970,9 +970,6 @@ configs:
   node-exporter-node-meta:
     name: node-exporter-node-meta-v1
     file: ./node-exporter/node_meta.prom
-  prometheus:
-    name: prometheus
-    external: true
   prometheus-blackbox-exporter:
     name: prometheus-blackbox-exporter-v1
     file: ./blackbox-exporter/prometheus/blackbox-exporter.yml

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -105,8 +105,8 @@ services:
       target: /var/lib/docker
       read_only: true
     - type: bind
-      source: /var/run
-      target: /var/run
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
       read_only: true
     - type: bind
       source: /dev/kmsg

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -802,7 +802,7 @@ services:
       interval: 30s
       retries: 3
       start_period: 30s
-    image: docker.io/prom/prometheus:v2.53.1
+    image: docker.io/prom/prometheus:v3.0.0
     logging:
       driver: json-file
       options:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -105,8 +105,8 @@ services:
       target: /var/lib/docker
       read_only: true
     - type: bind
-      source: /var/run/docker.sock
-      target: /var/run/docker.sock
+      source: /var/run
+      target: /var/run
       read_only: true
     - type: bind
       source: /dev/kmsg

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -916,6 +916,11 @@ configs:
     file: ./grafana/grafana/dashboards/promstack-cadvisor.json
     labels:
       io.grafana.dashboard: "true"
+  gf-dashboard-promstack-dockerstack:
+    name: gf-dashboard-promstack-dockerstack-v1
+    file: ./grafana/grafana/dashboards/promstack-dockerstack.json
+    labels:
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-dockerswarm-nodes:
     name: gf-dashboard-promstack-dockerswarm-nodes-v1
     file: ./grafana/grafana/dashboards/promstack-dockerswarm-nodes.json

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -41,10 +41,10 @@ services:
       prometheus_gwnetwork:
         aliases:
         - blackbox-exporter.internal
-        - blackbox-exporter.svc.promstack.local
+        - blackbox-exporter.svc.cluster.local
       public:
         aliases:
-        - blackbox-exporter.svc.promstack.local
+        - blackbox-exporter.svc.cluster.local
   cadvisor:
     cap_add:
     - SYSLOG
@@ -882,11 +882,11 @@ services:
     networks:
       prometheus:
         aliases:
-        - pushgateway.svc.promstack.local
+        - pushgateway.svc.cluster.local
       prometheus_gwnetwork:
         aliases:
         - pushgateway.internal
-        - pushgateway.svc.promstack.local
+        - pushgateway.svc.cluster.local
 networks:
   grafana: {}
   prometheus:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -49,7 +49,8 @@ services:
     cap_add:
     - SYSLOG
     command:
-    - -docker_only
+    - --docker_only
+    - --enable_load_reader=true
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -50,7 +50,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -allow_dynamic_housekeeping=true
+    - -housekeeping_interval=5s
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -178,7 +178,7 @@ services:
       interval: 30s
       retries: 3
       start_period: 30s
-    image: docker.io/grafana/grafana:11.1.0
+    image: docker.io/grafana/grafana:11.3.0
     logging:
       driver: json-file
       options:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -50,7 +50,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -housekeeping_interval=5s
+    - -housekeeping_interval=10s
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -49,8 +49,7 @@ services:
     cap_add:
     - SYSLOG
     command:
-    - -docker_only=true
-    - -housekeeping_interval=10s
+    - -docker_only
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -50,7 +50,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -housekeeping_interval=5s
+    - -allow_dynamic_housekeeping=true
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -576,7 +576,7 @@ services:
         constraints:
         - node.labels.services.promstack_prometheus_server == true
     environment:
-      PROMETHEUS_ALERTMANAGER_ADDR: ${PROMETHEUS_ALERTMANAGER_ADDR:-tasks.grafana.svc.cluster.local}
+      PROMETHEUS_ALERTMANAGER_ADDR: ${PROMETHEUS_ALERTMANAGER_ADDR:-tasks.grafana.internal}
       PROMETHEUS_ALERTMANAGER_PORT: ${PROMETHEUS_ALERTMANAGER_PORT:-9094}
       PROMETHEUS_CLUSTER_NAME: ${PROMETHEUS_CLUSTER_NAME:-{{ index .Service.Labels
         "com.docker.stack.namespace"}}}

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -874,7 +874,7 @@ services:
       placement:
         max_replicas_per_node: 1
     hostname: replica-{{.Task.Slot}}.pushgateway.internal
-    image: docker.io/prom/pushgateway:v1.9.0
+    image: docker.io/prom/pushgateway:v1.10.0
     logging:
       driver: json-file
       options:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -50,7 +50,7 @@ services:
     - SYSLOG
     command:
     - -docker_only=true
-    - -housekeeping_interval=10s
+    - -housekeeping_interval=5s
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -49,8 +49,7 @@ services:
     cap_add:
     - SYSLOG
     command:
-    - --docker_only
-    - --enable_load_reader=true
+    - -docker_only
     configs:
     - source: prometheus-cadvisor
     deploy:

--- a/grafana/docker-stack.tmpl.yml
+++ b/grafana/docker-stack.tmpl.yml
@@ -321,56 +321,56 @@ configs:
     name: gf-provisioning-datasource-prometheus-v1
     file: ./grafana/provisioning/datasources/prometheus.yaml
     labels:
-      - "io.grafana.provisioning.datasource=true"
+      io.grafana.provisioning.datasource: "true"
 
   # Grafana & Prometheus dashboards
   gf-dashboard-promstack-grafana-metrics:
     name: gf-dashboard-promstack-grafana-metrics-v1
     file: ./grafana/dashboards/promstack-grafana-metrics.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-prometheus-stats:
     name: gf-dashboard-promstack-prometheus-stats-v1
     file: ./grafana/dashboards/promstack-prometheus-stats.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-prometheus-stats-v2:
     name: gf-dashboard-promstack-prometheus-stats-v2
     file: ./grafana/dashboards/promstack-prometheus-2-0-stats.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
 
   # Docker Swarm specific dashboards
   gf-dashboard-promstack-dockerstack:
     name: gf-dashboard-promstack-dockerstack-v1
     file: ./grafana/dashboards/promstack-dockerstack.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-dockerswarm-nodes:
     name: gf-dashboard-promstack-dockerswarm-nodes-v1
     file: ./grafana/dashboards/promstack-dockerswarm-nodes.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-dockerswarm-services-endpoints:
     name: gf-dashboard-promstack-dockerswarm-services-endpoints-v1
     file: ./grafana/dashboards/promstack-dockerswarm-services-endpoints.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-dockerswarm-services:
     name: gf-dashboard-promstack-dockerswarm-services-v1
     file: ./grafana/dashboards/promstack-dockerswarm-services.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
 
   # cAdvisor
   gf-dashboard-promstack-cadvisor:
     name: gf-dashboard-promstack-cadvisor-v1
     file: ./grafana/dashboards/promstack-cadvisor.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"
   # Node Exporter
   gf-dashboard-promstack-node-exporter:
     name: gf-dashboard-promstack-node-exporter-v1
     file: ./grafana/dashboards/promstack-node-exporter.json
     labels:
-      - "io.grafana.dashboard=true"
+      io.grafana.dashboard: "true"

--- a/grafana/docker-stack.tmpl.yml
+++ b/grafana/docker-stack.tmpl.yml
@@ -341,6 +341,11 @@ configs:
       - "io.grafana.dashboard=true"
 
   # Docker Swarm specific dashboards
+  gf-dashboard-promstack-dockerstack:
+    name: gf-dashboard-promstack-dockerstack-v1
+    file: ./grafana/dashboards/promstack-dockerstack.json
+    labels:
+      - "io.grafana.dashboard=true"
   gf-dashboard-promstack-dockerswarm-nodes:
     name: gf-dashboard-promstack-dockerswarm-nodes-v1
     file: ./grafana/dashboards/promstack-dockerswarm-nodes.json

--- a/grafana/docker-stack.yml
+++ b/grafana/docker-stack.yml
@@ -64,7 +64,7 @@ services:
       interval: 30s
       retries: 3
       start_period: 30s
-    image: docker.io/grafana/grafana:11.1.0
+    image: docker.io/grafana/grafana:11.3.0
     logging:
       driver: json-file
       options:

--- a/grafana/docker-stack.yml
+++ b/grafana/docker-stack.yml
@@ -393,6 +393,11 @@ configs:
     file: ./grafana/dashboards/promstack-cadvisor.json
     labels:
       io.grafana.dashboard: "true"
+  gf-dashboard-promstack-dockerstack:
+    name: gf-dashboard-promstack-dockerstack-v1
+    file: ./grafana/dashboards/promstack-dockerstack.json
+    labels:
+      io.grafana.dashboard: "true"
   gf-dashboard-promstack-dockerswarm-nodes:
     name: gf-dashboard-promstack-dockerswarm-nodes-v1
     file: ./grafana/dashboards/promstack-dockerswarm-nodes.json

--- a/grafana/grafana/dashboards/promstack-dockerstack.json
+++ b/grafana/grafana/dashboards/promstack-dockerstack.json
@@ -1,0 +1,816 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "id": 17,
+    "links": [],
+    "panels": [
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 3,
+            "panels": [],
+            "title": "",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byValue",
+                            "options": {
+                                "op": "gte",
+                                "reducer": "allIsZero",
+                                "value": 0
+                            }
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hideFrom",
+                                "value": {
+                                    "legend": true,
+                                    "tooltip": true,
+                                    "viz": false
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byValue",
+                            "options": {
+                                "op": "gte",
+                                "reducer": "allIsNull",
+                                "value": 0
+                            }
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hideFrom",
+                                "value": {
+                                    "legend": true,
+                                    "tooltip": true,
+                                    "viz": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 1
+            },
+            "id": 51,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[1m])) by (dockerswarm_service_name) * 100 ",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{task}}",
+                    "range": true,
+                    "refId": "A",
+                    "step": 2
+                }
+            ],
+            "title": "CPU usage by Service",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 7
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(container_memory_usage_bytes{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (dockerswarm_service_name) ",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "Used {{dockerswarm_service_name}}",
+                    "range": true,
+                    "refId": "A",
+                    "step": 2
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(container_memory_cache{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (dockerswarm_service_name) ",
+                    "format": "time_series",
+                    "hide": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "Cached {{dockerswarm_service_name}}",
+                    "range": true,
+                    "refId": "B",
+                    "step": 2
+                }
+            ],
+            "title": "Memory usage by Service",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 13
+            },
+            "id": 4,
+            "panels": [],
+            "repeat": "service",
+            "title": "$service",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 14
+            },
+            "id": 20,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "promstack-prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(container_tasks_state{state=\"running\", dockerswarm_service_name=\"$service\"}) by (dockerswarm_service_name)",
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Replicas",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byValue",
+                            "options": {
+                                "op": "gte",
+                                "reducer": "allIsZero",
+                                "value": 0
+                            }
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hideFrom",
+                                "value": {
+                                    "legend": true,
+                                    "tooltip": true,
+                                    "viz": false
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byValue",
+                            "options": {
+                                "op": "gte",
+                                "reducer": "allIsNull",
+                                "value": 0
+                            }
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hideFrom",
+                                "value": {
+                                    "legend": true,
+                                    "tooltip": true,
+                                    "viz": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 20,
+                "x": 4,
+                "y": 14
+            },
+            "id": 1,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[1m])) by (task) * 100 ",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{task}}",
+                    "range": true,
+                    "refId": "A",
+                    "step": 2
+                }
+            ],
+            "title": "CPU usage by Service",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 4,
+                "y": 21
+            },
+            "id": 97,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(container_memory_usage_bytes{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (task) ",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "Used {{task}}",
+                    "range": true,
+                    "refId": "A",
+                    "step": 2
+                }
+            ],
+            "title": "Memory usage by Service",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 14,
+                "y": 21
+            },
+            "id": 158,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "maxHeight": 600,
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(container_memory_cache{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (task) ",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "Cached {{task}}",
+                    "range": true,
+                    "refId": "B",
+                    "step": 2
+                }
+            ],
+            "title": "Memory cached by Service",
+            "type": "timeseries"
+        }
+    ],
+    "preload": false,
+    "refresh": "5s",
+    "schemaVersion": 40,
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "text": "Promstack - Prometheus",
+                    "value": "promstack-prometheus"
+                },
+                "includeAll": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "text": "promstack",
+                    "value": "promstack"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "definition": "label_values(container_tasks_state,namespace)",
+                "includeAll": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "qryType": 1,
+                    "query": "label_values(container_tasks_state,namespace)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "type": "query"
+            },
+            {
+                "current": {
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                },
+                "definition": "label_values(container_tasks_state{namespace=~\"$namespace\"},dockerswarm_service_name)",
+                "includeAll": true,
+                "name": "service",
+                "options": [],
+                "query": {
+                    "qryType": 1,
+                    "query": "label_values(container_tasks_state{namespace=~\"$namespace\"},dockerswarm_service_name)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-5m",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Promstack - Docker Stack",
+    "uid": "ce3tf412944cgd",
+    "version": 11,
+    "weekStart": ""
+}

--- a/grafana/grafana/dashboards/promstack-dockerstack.json
+++ b/grafana/grafana/dashboards/promstack-dockerstack.json
@@ -18,7 +18,7 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 1,
-    "id": 17,
+    "id": 11,
     "links": [],
     "panels": [
         {
@@ -275,6 +275,7 @@
                     "editorMode": "code",
                     "expr": "sum(container_memory_usage_bytes{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (dockerswarm_service_name) ",
                     "format": "time_series",
+                    "hide": true,
                     "intervalFactor": 2,
                     "legendFormat": "Used {{dockerswarm_service_name}}",
                     "range": true,
@@ -294,6 +295,21 @@
                     "legendFormat": "Cached {{dockerswarm_service_name}}",
                     "range": true,
                     "refId": "B",
+                    "step": 2
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(container_memory_usage_bytes{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (dockerswarm_service_name) ",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 2,
+                    "legendFormat": "{{dockerswarm_service_name}}",
+                    "range": true,
+                    "refId": "C",
                     "step": 2
                 }
             ],
@@ -371,7 +387,7 @@
                         "uid": "promstack-prometheus"
                     },
                     "editorMode": "code",
-                    "expr": "count(container_tasks_state{state=\"running\", dockerswarm_service_name=\"$service\"}) by (dockerswarm_service_name)",
+                    "expr": "count(sum(irate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[1m])) by (task))",
                     "instant": false,
                     "legendFormat": "__auto",
                     "range": true,
@@ -604,7 +620,9 @@
                     ],
                     "displayMode": "table",
                     "placement": "bottom",
-                    "showLegend": true
+                    "showLegend": true,
+                    "sortBy": "Name",
+                    "sortDesc": true
                 },
                 "tooltip": {
                     "maxHeight": 600,
@@ -623,7 +641,7 @@
                     "expr": "sum(container_memory_usage_bytes{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (task) ",
                     "format": "time_series",
                     "intervalFactor": 2,
-                    "legendFormat": "Used {{task}}",
+                    "legendFormat": "{{task}}",
                     "range": true,
                     "refId": "A",
                     "step": 2
@@ -728,7 +746,7 @@
                     "expr": "sum(container_memory_cache{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (task) ",
                     "format": "time_series",
                     "intervalFactor": 2,
-                    "legendFormat": "Cached {{task}}",
+                    "legendFormat": "{{task}}",
                     "range": true,
                     "refId": "B",
                     "step": 2
@@ -811,6 +829,6 @@
     "timezone": "browser",
     "title": "Promstack - Docker Stack",
     "uid": "ce3tf412944cgd",
-    "version": 11,
+    "version": 8,
     "weekStart": ""
 }

--- a/grafana/grafana/dashboards/promstack-dockerstack.json
+++ b/grafana/grafana/dashboards/promstack-dockerstack.json
@@ -18,20 +18,184 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 1,
-    "id": 11,
+    "id": 6,
     "links": [],
     "panels": [
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "decimals": 0,
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 0,
+                "y": 0
+            },
+            "hideTimeOverride": true,
+            "id": 165,
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(count(container_tasks_state{namespace=\"$namespace\"}) by (container_label_com_docker_swarm_service_name))",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "range": true,
+                    "refId": "A",
+                    "step": 2
+                }
+            ],
+            "timeFrom": "1m",
+            "title": "Services",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "decimals": 0,
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 5,
+                "y": 0
+            },
+            "hideTimeOverride": true,
+            "id": 166,
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(rate(container_last_seen{namespace=~\"$namespace\"}[5m])) ",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "range": true,
+                    "refId": "A",
+                    "step": 2
+                }
+            ],
+            "timeFrom": "1m",
+            "title": "Containers",
+            "type": "stat"
+        },
         {
             "collapsed": false,
             "gridPos": {
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 0
+                "y": 4
             },
             "id": 3,
             "panels": [],
-            "title": "",
+            "title": "Stats",
             "type": "row"
         },
         {
@@ -140,7 +304,7 @@
                 "h": 6,
                 "w": 24,
                 "x": 0,
-                "y": 1
+                "y": 5
             },
             "id": 51,
             "options": {
@@ -177,7 +341,7 @@
                     "step": 2
                 }
             ],
-            "title": "CPU usage by Service",
+            "title": "CPU usage per service",
             "type": "timeseries"
         },
         {
@@ -243,9 +407,9 @@
             },
             "gridPos": {
                 "h": 6,
-                "w": 24,
+                "w": 12,
                 "x": 0,
-                "y": 7
+                "y": 11
             },
             "id": 2,
             "options": {
@@ -313,22 +477,8 @@
                     "step": 2
                 }
             ],
-            "title": "Memory usage by Service",
+            "title": "Memory usage per service",
             "type": "timeseries"
-        },
-        {
-            "collapsed": false,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 13
-            },
-            "id": 4,
-            "panels": [],
-            "repeat": "service",
-            "title": "$service",
-            "type": "row"
         },
         {
             "datasource": {
@@ -337,6 +487,42 @@
             },
             "fieldConfig": {
                 "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
                     "mappings": [],
                     "thresholds": {
                         "mode": "absolute",
@@ -351,51 +537,267 @@
                             }
                         ]
                     },
-                    "unit": "short"
+                    "unit": "bytes"
                 },
                 "overrides": []
             },
             "gridPos": {
-                "h": 5,
-                "w": 4,
-                "x": 0,
-                "y": 14
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 11
             },
-            "id": 20,
+            "id": 162,
             "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
+                "legend": {
                     "calcs": [
-                        "lastNotNull"
+                        "mean",
+                        "max"
                     ],
-                    "fields": "",
-                    "values": false
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
                 },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
             },
             "pluginVersion": "11.3.0",
             "targets": [
                 {
                     "datasource": {
                         "type": "prometheus",
-                        "uid": "promstack-prometheus"
+                        "uid": "${datasource}"
                     },
                     "editorMode": "code",
-                    "expr": "count(sum(irate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[1m])) by (task))",
-                    "instant": false,
-                    "legendFormat": "__auto",
+                    "expr": "sum(container_memory_cache{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}) by (dockerswarm_service_name)",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{dockerswarm_service_name}}",
                     "range": true,
                     "refId": "A"
                 }
             ],
-            "title": "Replicas",
-            "type": "stat"
+            "title": "Memory cached per service",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "Bps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 17
+            },
+            "id": 160,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[5m])) by (dockerswarm_service_name)",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{dockerswarm_service_name}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Received network traffic per service",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "Bps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 17
+            },
+            "id": 161,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[5m])) by (dockerswarm_service_name)",
+                    "interval": "",
+                    "legendFormat": "{{dockerswarm_service_name}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Sent network traffic per service",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 23
+            },
+            "id": 4,
+            "panels": [],
+            "repeat": "service",
+            "title": "Service: $service",
+            "type": "row"
         },
         {
             "datasource": {
@@ -500,10 +902,10 @@
                 ]
             },
             "gridPos": {
-                "h": 7,
-                "w": 20,
-                "x": 4,
-                "y": 14
+                "h": 5,
+                "w": 24,
+                "x": 0,
+                "y": 24
             },
             "id": 1,
             "options": {
@@ -540,7 +942,7 @@
                     "step": 2
                 }
             ],
-            "title": "CPU usage by Service",
+            "title": "CPU usage per task",
             "type": "timeseries"
         },
         {
@@ -605,10 +1007,10 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 7,
-                "w": 10,
-                "x": 4,
-                "y": 21
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 29
             },
             "id": 97,
             "options": {
@@ -619,7 +1021,7 @@
                         "min"
                     ],
                     "displayMode": "table",
-                    "placement": "bottom",
+                    "placement": "right",
                     "showLegend": true,
                     "sortBy": "Name",
                     "sortDesc": true
@@ -647,7 +1049,7 @@
                     "step": 2
                 }
             ],
-            "title": "Memory usage by Service",
+            "title": "Memory usage per task",
             "type": "timeseries"
         },
         {
@@ -712,10 +1114,10 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 7,
-                "w": 10,
-                "x": 14,
-                "y": 21
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 29
             },
             "id": 158,
             "options": {
@@ -726,7 +1128,7 @@
                         "min"
                     ],
                     "displayMode": "table",
-                    "placement": "bottom",
+                    "placement": "right",
                     "showLegend": true
                 },
                 "tooltip": {
@@ -752,8 +1154,421 @@
                     "step": 2
                 }
             ],
-            "title": "Memory cached by Service",
+            "title": "Memory cached per task",
             "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "Bps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 34
+            },
+            "id": 163,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "sortBy": "Mean",
+                    "sortDesc": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[5m])) by (task)",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{task}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Received network traffic per task",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "Bps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 34
+            },
+            "id": 164,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "mean",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[5m])) by (task)",
+                    "interval": "",
+                    "legendFormat": "{{task}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Sent network traffic per task",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 39
+            },
+            "id": 20,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(rate(container_last_seen{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"}[1m])) ",
+                    "hide": false,
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Replicas",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "auto",
+                            "wrapText": false
+                        },
+                        "filterable": false,
+                        "inspect": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Running"
+                        },
+                        "properties": [
+                            {
+                                "id": "unit",
+                                "value": "d"
+                            },
+                            {
+                                "id": "custom.cellOptions",
+                                "value": {
+                                    "type": "color-text"
+                                }
+                            },
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "dark-green",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 20,
+                "x": 4,
+                "y": 39
+            },
+            "id": 159,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "enablePagination": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "11.3.0",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "promstack-prometheus"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum((time() - container_start_time_seconds{namespace=~\"$namespace\", dockerswarm_service_name=~\"$service\"})/8640) by (image, task, node_id)",
+                    "format": "table",
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "A"
+                }
+            ],
+            "title": "Info",
+            "transformations": [
+                {
+                    "id": "filterFieldsByName",
+                    "options": {
+                        "include": {
+                            "names": [
+                                "node_id",
+                                "task",
+                                "Value",
+                                "image"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {
+                            "image": true,
+                            "node_id": false
+                        },
+                        "includeByName": {},
+                        "indexByName": {
+                            "Value": 3,
+                            "image": 1,
+                            "node_id": 2,
+                            "task": 0
+                        },
+                        "renameByName": {
+                            "Value": "Running",
+                            "image": "Image",
+                            "node_id": "Node",
+                            "task": "Name"
+                        }
+                    }
+                }
+            ],
+            "type": "table"
         }
     ],
     "preload": false,
@@ -808,6 +1623,7 @@
                 },
                 "definition": "label_values(container_tasks_state{namespace=~\"$namespace\"},dockerswarm_service_name)",
                 "includeAll": true,
+                "multi": true,
                 "name": "service",
                 "options": [],
                 "query": {
@@ -828,7 +1644,7 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "Promstack - Docker Stack",
-    "uid": "ce3tf412944cgd",
-    "version": 8,
+    "uid": "promstack-dockerstack",
+    "version": 1,
     "weekStart": ""
 }

--- a/node-exporter/docker-stack.tmpl.yml
+++ b/node-exporter/docker-stack.tmpl.yml
@@ -88,7 +88,7 @@ configs:
     name: prometheus-node-exporter-v1
     file: ./prometheus/node_exporter.yml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
 
 networks:
   prometheus_gwnetwork:

--- a/prometheus/docker-stack.tmpl.yml
+++ b/prometheus/docker-stack.tmpl.yml
@@ -299,31 +299,31 @@ configs:
     name: prometheus-dockerswarm-nodes-rule-v1
     file: ./prometheus/rules/dockerswarm-nodes.yaml
     labels:
-      - "io.prometheus.rule=true"
+      io.prometheus.rule: "true"
   prometheus-dockerswarm-services-rule:
     name: prometheus-dockerswarm-services-rule-v1
     file: ./prometheus/rules/dockerswarm-tasks.yaml
     labels:
-      - "io.prometheus.rule=true"
+      io.prometheus.rule: "true"
 
   # Prometheus's scrape config files
   prometheus-dockerswarm-nodes:
     name: prometheus-dockerswarm-nodes-v1
     file: ./prometheus/scrape-configs/dockerswarm-nodes.yaml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
   prometheus-dockerswarm-services-endpoints-host:
     name: prometheus-dockerswarm-services-endpoints-host-v1
     file: ./prometheus/scrape-configs/dockerswarm-services-endpoints-host.yaml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
   prometheus-dockerswarm-services-endpoints-ingress:
     name: prometheus-dockerswarm-services-endpoints-ingress-v1
     file: ./prometheus/scrape-configs/dockerswarm-services-endpoints-ingress.yaml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
   prometheus-dockerswarm-services:
     name: prometheus-dockerswarm-services-v1
     file: ./prometheus/scrape-configs/dockerswarm-services.yaml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"

--- a/prometheus/docker-stack.tmpl.yml
+++ b/prometheus/docker-stack.tmpl.yml
@@ -126,7 +126,7 @@ services:
       - --out=/prometheus-configs.d/prometheus.yaml
     environment:
       # Grafana unified alerting
-      - PROMETHEUS_ALERTMANAGER_ADDR=$${PROMETHEUS_ALERTMANAGER_ADDR:-tasks.grafana.svc.cluster.local}
+      - PROMETHEUS_ALERTMANAGER_ADDR=$${PROMETHEUS_ALERTMANAGER_ADDR:-tasks.grafana.internal}
       - PROMETHEUS_ALERTMANAGER_PORT=$${PROMETHEUS_ALERTMANAGER_PORT:-9094}
       # Prometheus cluster settings
       - PROMETHEUS_CLUSTER_NAME=$${PROMETHEUS_CLUSTER_NAME:-{{ index .Service.Labels "com.docker.stack.namespace"}}}

--- a/prometheus/docker-stack.yml
+++ b/prometheus/docker-stack.yml
@@ -33,7 +33,7 @@ services:
         constraints:
         - node.labels.services.promstack_prometheus_server == true
     environment:
-      PROMETHEUS_ALERTMANAGER_ADDR: ${PROMETHEUS_ALERTMANAGER_ADDR:-tasks.grafana.svc.cluster.local}
+      PROMETHEUS_ALERTMANAGER_ADDR: ${PROMETHEUS_ALERTMANAGER_ADDR:-tasks.grafana.internal}
       PROMETHEUS_ALERTMANAGER_PORT: ${PROMETHEUS_ALERTMANAGER_PORT:-9094}
       PROMETHEUS_CLUSTER_NAME: ${PROMETHEUS_CLUSTER_NAME:-{{ index .Service.Labels
         "com.docker.stack.namespace"}}}

--- a/prometheus/docker-stack.yml
+++ b/prometheus/docker-stack.yml
@@ -258,7 +258,7 @@ services:
       interval: 30s
       retries: 3
       start_period: 30s
-    image: docker.io/prom/prometheus:v2.53.1
+    image: docker.io/prom/prometheus:v3.0.0
     logging:
       driver: json-file
       options:

--- a/prometheus/prometheus/rules/dockerswarm-nodes.yaml
+++ b/prometheus/prometheus/rules/dockerswarm-nodes.yaml
@@ -7,6 +7,7 @@ groups:
       node_meta * 100) BY (node_name)) > 50
     for: 1m
     labels:
+      datasource: promstack-prometheus
       severity: warning
     annotations:
       description: Swarm node {{ $labels.node_name }} CPU usage is at {{ humanize
@@ -17,6 +18,7 @@ groups:
       * ON(instance) GROUP_LEFT(node_name) node_meta * 100) BY (node_name) > 80
     for: 1m
     labels:
+      datasource: promstack-prometheus
       severity: warning
     annotations:
       description: Swarm node {{ $labels.node_name }} memory usage is at {{ humanize
@@ -28,6 +30,7 @@ groups:
       node_meta > 85
     for: 1m
     labels:
+      datasource: promstack-prometheus
       severity: warning
     annotations:
       description: Swarm node {{ $labels.node_name }} disk usage is at {{ humanize
@@ -38,6 +41,7 @@ groups:
       GROUP_LEFT(node_name) node_meta < 0
     for: 1h
     labels:
+      datasource: promstack-prometheus
       severity: critical
     annotations:
       description: Swarm node {{ $labels.node_name }} disk is going to fill up in

--- a/prometheus/prometheus/rules/dockerswarm-tasks.yaml
+++ b/prometheus/prometheus/rules/dockerswarm-tasks.yaml
@@ -7,6 +7,9 @@ groups:
       BY (container_label_com_docker_swarm_task_name, container_label_com_docker_swarm_node_id)
       * 100 > 50
     for: 1m
+    labels:
+      datasource: promstack-prometheus
+      severity: critical
     annotations:
       description: '{{ $labels.container_label_com_docker_swarm_task_name }} on ''{{
         $labels.container_label_com_docker_swarm_node_id }}'' CPU usage is at {{ humanize
@@ -17,6 +20,9 @@ groups:
     expr: sum(container_memory_rss{container_label_com_docker_swarm_task_name=~".+"})
       BY (container_label_com_docker_swarm_task_name, container_label_com_docker_swarm_node_id) > 1e+09
     for: 1m
+    labels:
+      datasource: promstack-prometheus
+      severity: critical
     annotations:
       description: '{{ $labels.container_label_com_docker_swarm_task_name }} on ''{{
         $labels.container_label_com_docker_swarm_node_id }}'' memory usage is {{ humanize

--- a/prometheus/prometheus/scrape-configs/dockerswarm-services-endpoints-host.yaml
+++ b/prometheus/prometheus/scrape-configs/dockerswarm-services-endpoints-host.yaml
@@ -83,7 +83,7 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - target_label: __address__
-        replacement: tasks.blackbox-exporter.svc.promstack.local:9115
+        replacement: tasks.blackbox-exporter.internal:9115
       - source_labels: [__param_target]
         target_label: instance
 

--- a/prometheus/prometheus/scrape-configs/dockerswarm-services-endpoints-ingress.yaml
+++ b/prometheus/prometheus/scrape-configs/dockerswarm-services-endpoints-ingress.yaml
@@ -61,7 +61,7 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - target_label: __address__
-        replacement: tasks.blackbox-exporter.svc.promstack.local:9115
+        replacement: tasks.blackbox-exporter.internal:9115
       - source_labels: [__param_target]
         target_label: instance
 

--- a/pushgateway/docker-stack.tmpl.yml
+++ b/pushgateway/docker-stack.tmpl.yml
@@ -63,7 +63,7 @@ configs:
     name: prometheus-pushgateway-v1
     file: ./prometheus/pushgateway.yml
     labels:
-      - "io.prometheus.scrape_config=true"
+      io.prometheus.scrape_config: "true"
 
 networks:
   prometheus_gwnetwork:

--- a/pushgateway/docker-stack.tmpl.yml
+++ b/pushgateway/docker-stack.tmpl.yml
@@ -59,9 +59,6 @@ services:
         max_failure_ratio: 0.1
 
 configs:
-  prometheus:
-    name: prometheus
-    external: true
   prometheus-pushgateway:
     name: prometheus-pushgateway-v1
     file: ./prometheus/pushgateway.yml

--- a/pushgateway/docker-stack.tmpl.yml
+++ b/pushgateway/docker-stack.tmpl.yml
@@ -22,11 +22,11 @@ services:
     networks:
       prometheus:
         aliases:
-          - pushgateway.svc.promstack.local
+          - pushgateway.svc.cluster.local
       prometheus_gwnetwork:
         aliases:
           - pushgateway.internal
-          - pushgateway.svc.promstack.local
+          - pushgateway.svc.cluster.local
     hostname: replica-{{.Task.Slot}}.pushgateway.internal
     configs:
       - source: prometheus-pushgateway

--- a/pushgateway/docker-stack.yml
+++ b/pushgateway/docker-stack.yml
@@ -31,7 +31,7 @@ services:
       placement:
         max_replicas_per_node: 1
     hostname: replica-{{.Task.Slot}}.pushgateway.internal
-    image: docker.io/prom/pushgateway:v1.9.0
+    image: docker.io/prom/pushgateway:v1.10.0
     logging:
       driver: json-file
       options:

--- a/pushgateway/docker-stack.yml
+++ b/pushgateway/docker-stack.yml
@@ -40,11 +40,11 @@ services:
     networks:
       prometheus:
         aliases:
-        - pushgateway.svc.promstack.local
+        - pushgateway.svc.cluster.local
       prometheus_gwnetwork:
         aliases:
         - pushgateway.internal
-        - pushgateway.svc.promstack.local
+        - pushgateway.svc.cluster.local
 networks:
   prometheus_gwnetwork:
     name: prometheus_gwnetwork

--- a/pushgateway/docker-stack.yml
+++ b/pushgateway/docker-stack.yml
@@ -50,9 +50,6 @@ networks:
     name: prometheus_gwnetwork
     external: true
 configs:
-  prometheus:
-    name: prometheus
-    external: true
   prometheus-pushgateway:
     name: prometheus-pushgateway-v1
     file: ./prometheus/pushgateway.yml


### PR DESCRIPTION
## What's news?
- Introduce [unattended installer](https://github.com/swarmlibs/docker-promstack)
- Upgrade `prometheus` to v3.0.0
- Update `pushgateway` to v1.10.0
- Update `grafana` to v11.3.0
- Add `Promstack - Docker Stack` dashboard for Grafana

**Screenshots**:
![prometheus](https://github.com/user-attachments/assets/72f67f1e-e59c-45ca-bac6-ed87d70a3293)
![grafana](https://github.com/user-attachments/assets/7c0719c1-8412-4fe1-b465-42f7b7901f7b)
